### PR TITLE
Fix GGP linking

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -100,8 +100,8 @@ target_link_libraries(${PROJECT_NAME}
 )
 
 if(GGP)
-  target_link_libraries(${PROJECT_NAME} 
-    PRIVATE ${GGP_LIBRARY_PATH}/lib/libggp.so	
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE ${GGP_LIBRARY_PATH}/libggp.so
             dl
             pthread)
 endif()


### PR DESCRIPTION
This is required to get a GGP SDK to link properly. I'm not sure if this will break Windows. I'm also unsure if this is perhaps related to the particular GGP SDK version being used.