### PR TITLE
Fix linking of libggp.so

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -100,8 +100,8 @@ target_link_libraries(${PROJECT_NAME}
 )
 
 if(GGP)
-  target_link_libraries(${PROJECT_NAME} 
-    PRIVATE ${GGP_LIBRARY_PATH}/lib/libggp.so	
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE ggp
             dl
             pthread)
 endif()


### PR DESCRIPTION
The path to libggp.so is already present on CMAKE_LIBRARY_PATH and does not require an explicit path. This helps to resolve any discrepancies with the definition of GGP_LIBRARY_PATH.