### PR TITLE
Enable float16/int8 support to device

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -43,6 +43,12 @@ void VkexInfoApp::Configure(const vkex::ArgParser& args,
 
   configuration.optional_device_extensions.push_back(
       VK_EXT_SAMPLE_LOCATIONS_EXTENSION_NAME);
+  configuration.optional_device_extensions.push_back(
+      VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME);
+  configuration.optional_device_extensions.push_back(
+      VK_KHR_16BIT_STORAGE_EXTENSION_NAME);
+  configuration.optional_device_extensions.push_back(
+      VK_KHR_8BIT_STORAGE_EXTENSION_NAME);
 
 #if defined(ENABLE_VALIDATION)
   configuration.graphics_debug.enable = true;

--- a/src/vkex/Device.cpp
+++ b/src/vkex/Device.cpp
@@ -197,19 +197,26 @@ void CPhysicalDevice::InitializeExtensionProperties() {
 }
 
 void CPhysicalDevice::InitializeFeatures() {
-    m_extension_owned_features.shader_float16_int8_features = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FLOAT16_INT8_FEATURES_KHR };
-    m_extension_owned_features.storage_16bit_features = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES };
-    m_extension_owned_features.storage_8bit_features = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_8BIT_STORAGE_FEATURES_KHR };
+  m_extension_owned_features.shader_float16_int8_features = {
+    VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FLOAT16_INT8_FEATURES_KHR };
+  m_extension_owned_features.storage_16bit_features = {
+    VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES };
+  m_extension_owned_features.storage_8bit_features = {
+    VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_8BIT_STORAGE_FEATURES_KHR };
 
-    m_extension_owned_features.shader_float16_int8_features.pNext = &m_extension_owned_features.storage_16bit_features;
-    m_extension_owned_features.storage_16bit_features.pNext = &m_extension_owned_features.storage_8bit_features;
+  m_extension_owned_features.shader_float16_int8_features.pNext =
+    &m_extension_owned_features.storage_16bit_features;
+  m_extension_owned_features.storage_16bit_features.pNext =
+    &m_extension_owned_features.storage_8bit_features;
 
-    m_vk_physical_device_features = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2 };
-    m_vk_physical_device_features.pNext = &m_extension_owned_features.shader_float16_int8_features;
+  m_vk_physical_device_features = {
+    VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2 };
+  m_vk_physical_device_features.pNext =
+    &m_extension_owned_features.shader_float16_int8_features;
 
-    vkex::GetPhysicalDeviceFeatures2(
-        m_create_info.vk_object,
-        &m_vk_physical_device_features);
+  vkex::GetPhysicalDeviceFeatures2(
+    m_create_info.vk_object,
+    &m_vk_physical_device_features);
 }
 
 bool CPhysicalDevice::GetQueueFamilyProperties(
@@ -412,31 +419,36 @@ vkex::Result CDevice::InitializeQueueRequests()
 
 void CDevice::InitializeExtensionFeatures()
 {
-    m_create_info.app_p_next = m_create_info.p_next;
-    void* current_p_next = const_cast<void *>(m_create_info.p_next);
+  m_create_info.app_p_next = m_create_info.p_next;
+  void* current_p_next = const_cast<void *>(m_create_info.p_next);
 
-    const PhysicalDeviceExtensionFeatures& queried_extension_features = m_create_info.physical_device->GetPhysicalDeviceExtensionFeatures();
-    PhysicalDeviceExtensionFeatures& requested_extension_features = m_create_info.extension_features;
+  const PhysicalDeviceExtensionFeatures& queried_extension_features =
+    m_create_info.physical_device->GetPhysicalDeviceExtensionFeatures();
+  PhysicalDeviceExtensionFeatures& requested_extension_features =
+    m_create_info.extension_features;
 
-    if (Contains(m_create_info.extensions, std::string(VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME))) {
-        requested_extension_features.shader_float16_int8_features = queried_extension_features.shader_float16_int8_features;
-        requested_extension_features.shader_float16_int8_features.pNext = current_p_next;
-        current_p_next = &(requested_extension_features.shader_float16_int8_features);
-    }
+  if (Contains(m_create_info.extensions, std::string(VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME))) {
+    requested_extension_features.shader_float16_int8_features =
+      queried_extension_features.shader_float16_int8_features;
+    requested_extension_features.shader_float16_int8_features.pNext = current_p_next;
+    current_p_next = &(requested_extension_features.shader_float16_int8_features);
+  }
 
-    if (Contains(m_create_info.extensions, std::string(VK_KHR_16BIT_STORAGE_EXTENSION_NAME))) {
-        requested_extension_features.storage_16bit_features = queried_extension_features.storage_16bit_features;
-        requested_extension_features.storage_16bit_features.pNext = current_p_next;
-        current_p_next = &(requested_extension_features.storage_16bit_features);
-    }
+  if (Contains(m_create_info.extensions, std::string(VK_KHR_16BIT_STORAGE_EXTENSION_NAME))) {
+    requested_extension_features.storage_16bit_features =
+      queried_extension_features.storage_16bit_features;
+    requested_extension_features.storage_16bit_features.pNext = current_p_next;
+    current_p_next = &(requested_extension_features.storage_16bit_features);
+  }
 
-    if (Contains(m_create_info.extensions, std::string(VK_KHR_8BIT_STORAGE_EXTENSION_NAME))) {
-        requested_extension_features.storage_8bit_features = queried_extension_features.storage_8bit_features;
-        requested_extension_features.storage_8bit_features.pNext = current_p_next;
-        current_p_next = &(requested_extension_features.storage_8bit_features);
-    }
+  if (Contains(m_create_info.extensions, std::string(VK_KHR_8BIT_STORAGE_EXTENSION_NAME))) {
+    requested_extension_features.storage_8bit_features =
+      queried_extension_features.storage_8bit_features;
+    requested_extension_features.storage_8bit_features.pNext = current_p_next;
+    current_p_next = &(requested_extension_features.storage_8bit_features);
+  }
 
-    m_create_info.p_next = current_p_next;
+  m_create_info.p_next = current_p_next;
 }
 
 vkex::Result CDevice::InitializeQueues()

--- a/src/vkex/Device.cpp
+++ b/src/vkex/Device.cpp
@@ -419,7 +419,6 @@ vkex::Result CDevice::InitializeQueueRequests()
 
 void CDevice::InitializeExtensionFeatures()
 {
-  m_create_info.app_p_next = m_create_info.p_next;
   void* current_p_next = const_cast<void *>(m_create_info.p_next);
 
   const PhysicalDeviceExtensionFeatures& queried_extension_features =

--- a/src/vkex/Device.cpp
+++ b/src/vkex/Device.cpp
@@ -419,7 +419,7 @@ vkex::Result CDevice::InitializeQueueRequests()
 
 void CDevice::InitializeExtensionFeatures()
 {
-  void* current_p_next = const_cast<void *>(m_create_info.p_next);
+  void* p_next_front = const_cast<void *>(m_create_info.p_next);
 
   const PhysicalDeviceExtensionFeatures& queried_extension_features =
     m_create_info.physical_device->GetPhysicalDeviceExtensionFeatures();
@@ -429,25 +429,25 @@ void CDevice::InitializeExtensionFeatures()
   if (Contains(m_create_info.extensions, std::string(VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME))) {
     requested_extension_features.shader_float16_int8_features =
       queried_extension_features.shader_float16_int8_features;
-    requested_extension_features.shader_float16_int8_features.pNext = current_p_next;
-    current_p_next = &(requested_extension_features.shader_float16_int8_features);
+    requested_extension_features.shader_float16_int8_features.pNext = p_next_front;
+    p_next_front = &(requested_extension_features.shader_float16_int8_features);
   }
 
   if (Contains(m_create_info.extensions, std::string(VK_KHR_16BIT_STORAGE_EXTENSION_NAME))) {
     requested_extension_features.storage_16bit_features =
       queried_extension_features.storage_16bit_features;
-    requested_extension_features.storage_16bit_features.pNext = current_p_next;
-    current_p_next = &(requested_extension_features.storage_16bit_features);
+    requested_extension_features.storage_16bit_features.pNext = p_next_front;
+    p_next_front = &(requested_extension_features.storage_16bit_features);
   }
 
   if (Contains(m_create_info.extensions, std::string(VK_KHR_8BIT_STORAGE_EXTENSION_NAME))) {
     requested_extension_features.storage_8bit_features =
       queried_extension_features.storage_8bit_features;
-    requested_extension_features.storage_8bit_features.pNext = current_p_next;
-    current_p_next = &(requested_extension_features.storage_8bit_features);
+    requested_extension_features.storage_8bit_features.pNext = p_next_front;
+    p_next_front = &(requested_extension_features.storage_8bit_features);
   }
 
-  m_create_info.p_next = current_p_next;
+  m_create_info.p_next = p_next_front;
 }
 
 vkex::Result CDevice::InitializeQueues()

--- a/src/vkex/Device.cpp
+++ b/src/vkex/Device.cpp
@@ -410,6 +410,35 @@ vkex::Result CDevice::InitializeQueueRequests()
   return vkex::Result::Success;
 }
 
+void CDevice::InitializeExtensionFeatures()
+{
+    m_create_info.app_p_next = m_create_info.p_next;
+    void* current_p_next = const_cast<void *>(m_create_info.p_next);
+
+    const PhysicalDeviceExtensionFeatures& queried_extension_features = m_create_info.physical_device->GetPhysicalDeviceExtensionFeatures();
+    PhysicalDeviceExtensionFeatures& requested_extension_features = m_create_info.extension_features;
+
+    if (Contains(m_create_info.extensions, std::string(VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME))) {
+        requested_extension_features.shader_float16_int8_features = queried_extension_features.shader_float16_int8_features;
+        requested_extension_features.shader_float16_int8_features.pNext = current_p_next;
+        current_p_next = &(requested_extension_features.shader_float16_int8_features);
+    }
+
+    if (Contains(m_create_info.extensions, std::string(VK_KHR_16BIT_STORAGE_EXTENSION_NAME))) {
+        requested_extension_features.storage_16bit_features = queried_extension_features.storage_16bit_features;
+        requested_extension_features.storage_16bit_features.pNext = current_p_next;
+        current_p_next = &(requested_extension_features.storage_16bit_features);
+    }
+
+    if (Contains(m_create_info.extensions, std::string(VK_KHR_8BIT_STORAGE_EXTENSION_NAME))) {
+        requested_extension_features.storage_8bit_features = queried_extension_features.storage_8bit_features;
+        requested_extension_features.storage_8bit_features.pNext = current_p_next;
+        current_p_next = &(requested_extension_features.storage_8bit_features);
+    }
+
+    m_create_info.p_next = current_p_next;
+}
+
 vkex::Result CDevice::InitializeQueues()
 {
   std::vector<const void*> look_up_keys;
@@ -542,6 +571,8 @@ vkex::Result CDevice::InternalCreate(
     m_create_info.enabled_features.pipelineStatisticsQuery  = VK_TRUE;
     m_create_info.enabled_features.samplerAnisotropy        = VK_TRUE;
     m_create_info.enabled_features.sampleRateShading        = VK_TRUE;
+
+    InitializeExtensionFeatures();
   }
 
   // Create info

--- a/src/vkex/Device.cpp
+++ b/src/vkex/Device.cpp
@@ -62,12 +62,7 @@ vkex::Result CPhysicalDevice::InternalCreate(
   InitializeExtensionProperties();
 
   // Features
-  {
-    m_vk_physical_device_features = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2 };
-    vkex::GetPhysicalDeviceFeatures2(
-      m_create_info.vk_object, 
-      &m_vk_physical_device_features);
-  }
+  InitializeFeatures();
 
   // Queue family properties
   {
@@ -199,6 +194,22 @@ void CPhysicalDevice::InitializeExtensionProperties() {
                                          &properties_2);
     }
   }
+}
+
+void CPhysicalDevice::InitializeFeatures() {
+    m_extension_owned_features.shader_float16_int8_features = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FLOAT16_INT8_FEATURES_KHR };
+    m_extension_owned_features.storage_16bit_features = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES };
+    m_extension_owned_features.storage_8bit_features = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_8BIT_STORAGE_FEATURES_KHR };
+
+    m_extension_owned_features.shader_float16_int8_features.pNext = &m_extension_owned_features.storage_16bit_features;
+    m_extension_owned_features.storage_16bit_features.pNext = &m_extension_owned_features.storage_8bit_features;
+
+    m_vk_physical_device_features = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2 };
+    m_vk_physical_device_features.pNext = &m_extension_owned_features.shader_float16_int8_features;
+
+    vkex::GetPhysicalDeviceFeatures2(
+        m_create_info.vk_object,
+        &m_vk_physical_device_features);
 }
 
 bool CPhysicalDevice::GetQueueFamilyProperties(

--- a/src/vkex/Device.h
+++ b/src/vkex/Device.h
@@ -50,9 +50,9 @@ struct PhysicalDeviceCreateInfo {
  *
  */
 struct PhysicalDeviceExtensionFeatures {
-    VkPhysicalDeviceFloat16Int8FeaturesKHR shader_float16_int8_features;
-    VkPhysicalDevice16BitStorageFeaturesKHR storage_16bit_features;
-    VkPhysicalDevice8BitStorageFeaturesKHR storage_8bit_features;
+  VkPhysicalDeviceFloat16Int8FeaturesKHR shader_float16_int8_features;
+  VkPhysicalDevice16BitStorageFeaturesKHR storage_16bit_features;
+  VkPhysicalDevice8BitStorageFeaturesKHR storage_8bit_features;
 };
 
 /** @class IPhysicalDevice
@@ -141,7 +141,7 @@ public:
    *
    */
   const PhysicalDeviceExtensionFeatures& GetPhysicalDeviceExtensionFeatures() const {
-      return m_extension_owned_features;
+    return m_extension_owned_features;
   }
 
   /** @fn GetVkApiVersion

--- a/src/vkex/Device.h
+++ b/src/vkex/Device.h
@@ -203,6 +203,11 @@ private:
    */
   void InitializeExtensionProperties();
 
+  /** @fn InitializeFeatures
+   *
+   */
+  void InitializeFeatures();
+
   /** @fn SetInstance
    *
    */
@@ -227,6 +232,12 @@ private:
   struct {
     VkPhysicalDeviceSampleLocationsPropertiesEXT sample_locations_properties;
   } m_extension_owned_properties;
+
+  struct {
+      VkPhysicalDeviceFloat16Int8FeaturesKHR shader_float16_int8_features;
+      VkPhysicalDevice16BitStorageFeaturesKHR storage_16bit_features;
+      VkPhysicalDevice8BitStorageFeaturesKHR storage_8bit_features;
+  } m_extension_owned_features;
 
   mutable std::string                         m_descriptive_name;
 };

--- a/src/vkex/Device.h
+++ b/src/vkex/Device.h
@@ -276,7 +276,6 @@ struct DeviceCreateInfo {
   std::vector<std::string>              optional_extensions;
   VkPhysicalDeviceFeatures              enabled_features;
   PhysicalDeviceExtensionFeatures       extension_features;
-  const void*                           app_p_next;
   bool                                  safe_values;
 };
 

--- a/src/vkex/Device.h
+++ b/src/vkex/Device.h
@@ -46,6 +46,15 @@ struct PhysicalDeviceCreateInfo {
   VkPhysicalDevice  vk_object;
 };
 
+/** @struct PhysicalDeviceExtensionFeatures
+ *
+ */
+struct PhysicalDeviceExtensionFeatures {
+    VkPhysicalDeviceFloat16Int8FeaturesKHR shader_float16_int8_features;
+    VkPhysicalDevice16BitStorageFeaturesKHR storage_16bit_features;
+    VkPhysicalDevice8BitStorageFeaturesKHR storage_8bit_features;
+};
+
 /** @class IPhysicalDevice
  *
  */ 
@@ -126,6 +135,13 @@ public:
    */
   const VkPhysicalDeviceFeatures2& GetPhysicalDeviceFeatures() const {
     return m_vk_physical_device_features;
+  }
+
+  /** @fn GetPhysicalDeviceExtensionFeatures
+   *
+   */
+  const PhysicalDeviceExtensionFeatures& GetPhysicalDeviceExtensionFeatures() const {
+      return m_extension_owned_features;
   }
 
   /** @fn GetVkApiVersion
@@ -233,11 +249,7 @@ private:
     VkPhysicalDeviceSampleLocationsPropertiesEXT sample_locations_properties;
   } m_extension_owned_properties;
 
-  struct {
-      VkPhysicalDeviceFloat16Int8FeaturesKHR shader_float16_int8_features;
-      VkPhysicalDevice16BitStorageFeaturesKHR storage_16bit_features;
-      VkPhysicalDevice8BitStorageFeaturesKHR storage_8bit_features;
-  } m_extension_owned_features;
+  PhysicalDeviceExtensionFeatures m_extension_owned_features;
 
   mutable std::string                         m_descriptive_name;
 };
@@ -263,6 +275,8 @@ struct DeviceCreateInfo {
   std::vector<std::string>              extensions;
   std::vector<std::string>              optional_extensions;
   VkPhysicalDeviceFeatures              enabled_features;
+  PhysicalDeviceExtensionFeatures       extension_features;
+  const void*                           app_p_next;
   bool                                  safe_values;
 };
 
@@ -837,6 +851,11 @@ private:
    *
    */
   vkex::Result InitializeQueueRequests();
+
+  /** @fn InitializeExtensionFeatures
+   *
+   */
+  void InitializeExtensionFeatures();
 
   /** @fn InitializeQueues
    *


### PR DESCRIPTION
Try to enable float16/int8 support for shaders. Check if the relevant extensions are available, and if they are, flip on the appropriate device feature bits.

Formatting is a bit inconsistent in the `vkex` code because it doesn't have a .clang-format file. Because it's supposed to be a submodule 😛 